### PR TITLE
[Android] [히데] 달력 페이지 완성 

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -43,7 +43,6 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.4.1'
     implementation 'com.google.android.material:material:1.6.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
-    implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
@@ -63,4 +62,7 @@ dependencies {
 
     //Joda
     implementation 'joda-time:joda-time:2.10.10'
+
+    // repeatOnLifecycle API
+    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.4.0'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -65,4 +65,7 @@ dependencies {
 
     // repeatOnLifecycle API
     implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.4.0'
+
+    //PriceChart
+    implementation 'com.github.stfalcon-studio:StfalconPriceRangeBar-android:v1.5'
 }

--- a/app/src/main/java/com/example/airbnb/common/Constants.kt
+++ b/app/src/main/java/com/example/airbnb/common/Constants.kt
@@ -2,6 +2,7 @@ package com.example.airbnb.common
 
 object Constants {
     const val SUNDAY_DAY_OF_WEEK = 7
+    const val CALENDAR_IN_RANGE_COLOR= 0xFFF3F5F7.toInt()
 }
 
 enum class DayOfMonthRange(val range: IntRange) {

--- a/app/src/main/java/com/example/airbnb/domain/model/CalendarDay.kt
+++ b/app/src/main/java/com/example/airbnb/domain/model/CalendarDay.kt
@@ -1,7 +1,7 @@
 package com.example.airbnb.domain.model
 
 data class CalendarDay(
-    val year:Int,
+    val year: Int,
     val month: Int,
     val day: String = "",
     var isStartDay: Boolean = false,

--- a/app/src/main/java/com/example/airbnb/domain/model/CalendarDay.kt
+++ b/app/src/main/java/com/example/airbnb/domain/model/CalendarDay.kt
@@ -6,6 +6,4 @@ data class CalendarDay(
     val day: String = "",
     var isStartDay: Boolean = false,
     var isSelectable: Boolean = true,
-    var isSelected: Boolean = false,
-    var isInRange: Boolean = false
 )

--- a/app/src/main/java/com/example/airbnb/ui/calendar/CalendarFragment.kt
+++ b/app/src/main/java/com/example/airbnb/ui/calendar/CalendarFragment.kt
@@ -64,6 +64,7 @@ class CalendarFragment : Fragment() {
             monthAdapter.setCheckInAndCheckOut(it, viewModel.checkOutStatedFlow.value)
             monthAdapter.notifyDataSetChanged()
             checkDateSelection()
+            moveWithAllDataInput()
         }
     }
 
@@ -73,6 +74,7 @@ class CalendarFragment : Fragment() {
             monthAdapter.setCheckInAndCheckOut(viewModel.checkInStatedFlow.value, it)
             monthAdapter.notifyDataSetChanged()
             checkDateSelection()
+            moveWithAllDataInput()
         }
     }
 
@@ -90,10 +92,19 @@ class CalendarFragment : Fragment() {
         }
     }
 
+    private fun moveWithAllDataInput(){
+        if(nextBtn.isSelected){
+            nextBtn.setOnClickListener {
+                navigator.navigate(R.id.action_calendarFragment_to_priceRangeFragment)
+            }
+        }
+    }
+
     private fun addSkipOrEraseButton() {
         skipBtn.setOnClickListener {
             if (skipBtn.text ==  getString(R.string.skip_btn_title)) {
                 //가격 선택화면 이동
+                navigator.navigate(R.id.action_calendarFragment_to_priceRangeFragment)
             } else {
                 viewModel.eraseSelectedDate()
                 monthAdapter.notifyDataSetChanged()

--- a/app/src/main/java/com/example/airbnb/ui/calendar/CalendarFragment.kt
+++ b/app/src/main/java/com/example/airbnb/ui/calendar/CalendarFragment.kt
@@ -7,10 +7,14 @@ import android.view.ViewGroup
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import com.example.airbnb.R
 import com.example.airbnb.databinding.FragmentCalendarBinding
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
 import org.joda.time.LocalDate
-import org.joda.time.LocalDateTime
 
 class CalendarFragment : Fragment() {
 
@@ -27,13 +31,36 @@ class CalendarFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        val monthAdapter = MonthAdapter{
-            selectedDate -> selectDate(selectedDate)
+        val monthAdapter = MonthAdapter { selectedDate ->
+            selectDate(selectedDate)
         }
         binding.rvCalendar.adapter = monthAdapter
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                launch { setCheckIn() }
+                launch { setCheckOut() }
+            }
+        }
     }
 
-    private fun selectDate(selectedDate:LocalDate){
+    private suspend fun setCheckIn() {
+        viewModel.checkInStatedFlow.collect {
+            it?.let {
+                binding.checkIn = it
+            }
+        }
+    }
+
+    private suspend fun setCheckOut() {
+        viewModel.checkOutStatedFlow.collect {
+            it?.let {
+                binding.checkOut = it
+            }
+        }
+    }
+
+    private fun selectDate(selectedDate: LocalDate) {
         viewModel.saveDate(selectedDate)
 
     }

--- a/app/src/main/java/com/example/airbnb/ui/calendar/CalendarFragment.kt
+++ b/app/src/main/java/com/example/airbnb/ui/calendar/CalendarFragment.kt
@@ -4,12 +4,16 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Button
+import android.widget.ImageButton
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
+import androidx.navigation.NavController
+import androidx.navigation.Navigation
 import com.example.airbnb.R
 import com.example.airbnb.databinding.FragmentCalendarBinding
 import kotlinx.coroutines.flow.collect
@@ -21,6 +25,10 @@ class CalendarFragment : Fragment() {
     private val viewModel: CalendarViewModel by viewModels()
     private lateinit var binding: FragmentCalendarBinding
     private lateinit var monthAdapter: MonthAdapter
+    private lateinit var skipBtn: Button
+    private lateinit var nextBtn: ImageButton
+    private lateinit var navigator: NavController
+
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -32,17 +40,22 @@ class CalendarFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        navigator = Navigation.findNavController(view)
+        skipBtn = view.rootView.findViewById<Button>(R.id.btn_information_skip)
+        nextBtn = view.rootView.findViewById(R.id.iBtn_information_next)
+        println(skipBtn)
         monthAdapter = MonthAdapter { selectedDate ->
             selectDate(selectedDate)
         }
         binding.rvCalendar.adapter = monthAdapter
-
+        monthAdapter.submitCalendarMaps(viewModel.calendarDatMap)
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 launch { setCheckOut() }
                 launch { setCheckIn() }
             }
         }
+        addSkipOrEraseButton()
     }
 
     private suspend fun setCheckIn() {
@@ -50,7 +63,7 @@ class CalendarFragment : Fragment() {
             binding.checkIn = it
             monthAdapter.setCheckInAndCheckOut(it, viewModel.checkOutStatedFlow.value)
             monthAdapter.notifyDataSetChanged()
-
+            checkDateSelection()
         }
     }
 
@@ -59,11 +72,32 @@ class CalendarFragment : Fragment() {
             binding.checkOut = it
             monthAdapter.setCheckInAndCheckOut(viewModel.checkInStatedFlow.value, it)
             monthAdapter.notifyDataSetChanged()
+            checkDateSelection()
         }
     }
 
     private fun selectDate(selectedDate: LocalDate) {
         viewModel.saveDate(selectedDate)
+    }
 
+    private fun checkDateSelection() {
+        nextBtn.isSelected = binding.checkIn != null && binding.checkOut != null
+        if (binding.checkIn != null || binding.checkOut != null) {
+            skipBtn.text = getString(R.string.erase_btn_title)
+        }
+        else{
+            skipBtn.text=  getString(R.string.skip_btn_title)
+        }
+    }
+
+    private fun addSkipOrEraseButton() {
+        skipBtn.setOnClickListener {
+            if (skipBtn.text ==  getString(R.string.skip_btn_title)) {
+                //가격 선택화면 이동
+            } else {
+                viewModel.eraseSelectedDate()
+                monthAdapter.notifyDataSetChanged()
+            }
+        }
     }
 }

--- a/app/src/main/java/com/example/airbnb/ui/calendar/CalendarFragment.kt
+++ b/app/src/main/java/com/example/airbnb/ui/calendar/CalendarFragment.kt
@@ -39,23 +39,22 @@ class CalendarFragment : Fragment() {
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 launch { setCheckIn() }
-                launch { setCheckOut() }
+                launch { setCheckOut(monthAdapter) }
             }
         }
     }
 
     private suspend fun setCheckIn() {
         viewModel.checkInStatedFlow.collect {
-            it?.let {
-                binding.checkIn = it
-            }
+            binding.checkIn = it
         }
     }
 
-    private suspend fun setCheckOut() {
+    private suspend fun setCheckOut(monthAdapter: MonthAdapter) {
         viewModel.checkOutStatedFlow.collect {
+            binding.checkOut = it
             it?.let {
-                binding.checkOut = it
+                monthAdapter.setCheckInAndCheckOut(viewModel.checkInStatedFlow.value, it)
             }
         }
     }

--- a/app/src/main/java/com/example/airbnb/ui/calendar/CalendarViewModel.kt
+++ b/app/src/main/java/com/example/airbnb/ui/calendar/CalendarViewModel.kt
@@ -2,12 +2,18 @@ package com.example.airbnb.ui.calendar
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.airbnb.domain.model.CalendarDay
+import com.example.airbnb.ui.common.CalendarUtil
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import org.joda.time.LocalDate
+import org.joda.time.LocalDateTime
 
 class CalendarViewModel : ViewModel() {
+
+    private val _calendarDataMap :MutableMap<LocalDateTime, List<CalendarDay>> = mutableMapOf()
+    val calendarDatMap:Map<LocalDateTime, List<CalendarDay>> = _calendarDataMap
 
     private val _checkInStatedFlow = MutableStateFlow<LocalDate?>(null)
     val checkInStatedFlow: StateFlow<LocalDate?> = _checkInStatedFlow
@@ -40,5 +46,19 @@ class CalendarViewModel : ViewModel() {
             }
         }
     }
+    private fun makeCalendarData(){
+         val monthList = Array(12) { index -> LocalDateTime.now().plusMonths(index) }
+        monthList.forEach {
+            this._calendarDataMap[it] = CalendarUtil.getDayList(it)
+        }
+    }
 
+    fun eraseSelectedDate(){
+        this._checkInStatedFlow.value = null
+        this._checkOutStatedFlow.value= null
+    }
+
+    init {
+        makeCalendarData()
+    }
 }

--- a/app/src/main/java/com/example/airbnb/ui/calendar/CalendarViewModel.kt
+++ b/app/src/main/java/com/example/airbnb/ui/calendar/CalendarViewModel.kt
@@ -31,8 +31,6 @@ class CalendarViewModel : ViewModel() {
                         it.isAfter(dateTime) -> {
                             this.emit(dateTime)
                             _checkOutStatedFlow.emit(null)
-                            println("체크인 ${this.value}")
-                            println("체크아웃 ${_checkOutStatedFlow.value}")
                         }
                         else -> {
                             _checkOutStatedFlow.emit(dateTime)

--- a/app/src/main/java/com/example/airbnb/ui/calendar/CalendarViewModel.kt
+++ b/app/src/main/java/com/example/airbnb/ui/calendar/CalendarViewModel.kt
@@ -1,16 +1,58 @@
 package com.example.airbnb.ui.calendar
 
 import androidx.lifecycle.ViewModel
-import com.example.airbnb.data.RepositoryImpl
-import com.example.airbnb.domain.Repository
-import com.example.airbnb.domain.model.CalendarDay
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
 import org.joda.time.LocalDate
-import org.joda.time.LocalDateTime
 
 class CalendarViewModel : ViewModel() {
 
+    private val _checkInStatedFlow = MutableStateFlow<LocalDate?>(null)
+    val checkInStatedFlow: StateFlow<LocalDate?> = _checkInStatedFlow
+
+    private val _checkOutStatedFlow = MutableStateFlow<LocalDate?>(null)
+    val checkOutStatedFlow: StateFlow<LocalDate?> = _checkOutStatedFlow
+
     //클릭한 날짜 정보 viewModel까지 가져오는 테스트
-    fun saveDate(dateTime: LocalDate){
-        println(dateTime)
+    fun saveDate(dateTime: LocalDate) {
+        saveFirstSelectedDay(dateTime)
     }
+
+    private fun saveFirstSelectedDay(dateTime: LocalDate) {
+        viewModelScope.launch {
+            with(_checkInStatedFlow) {
+                this.value?.let {
+                    when {
+                        it.isEqual(dateTime) -> {
+                            this.emit(dateTime)
+                            _checkOutStatedFlow.emit(dateTime)
+                            println("체크인 ${this.value}")
+                            println("체크아웃 ${_checkOutStatedFlow.value}")
+                            return@launch
+                        }
+                        it.isAfter(dateTime) -> {
+                            this.emit(dateTime)
+                            _checkOutStatedFlow.emit(null)
+                            println("체크인 ${this.value}")
+                            println("체크아웃 ${_checkOutStatedFlow.value}")
+                            return@launch
+                        }
+                        else -> {
+                             _checkOutStatedFlow.emit(dateTime)
+                            println("체크인 ${this.value}")
+                            println("체크아웃 ${_checkOutStatedFlow.value}")
+                            return@launch
+                        }
+                    }
+                } ?: this.emit(dateTime)
+                println("체크인 ${this.value}")
+                println("체크아웃 ${_checkOutStatedFlow.value}")
+                return@launch
+            }
+        }
+    }
+
+
 }

--- a/app/src/main/java/com/example/airbnb/ui/calendar/CalendarViewModel.kt
+++ b/app/src/main/java/com/example/airbnb/ui/calendar/CalendarViewModel.kt
@@ -15,7 +15,6 @@ class CalendarViewModel : ViewModel() {
     private val _checkOutStatedFlow = MutableStateFlow<LocalDate?>(null)
     val checkOutStatedFlow: StateFlow<LocalDate?> = _checkOutStatedFlow
 
-    //클릭한 날짜 정보 viewModel까지 가져오는 테스트
     fun saveDate(dateTime: LocalDate) {
         saveFirstSelectedDay(dateTime)
     }
@@ -28,31 +27,20 @@ class CalendarViewModel : ViewModel() {
                         it.isEqual(dateTime) -> {
                             this.emit(dateTime)
                             _checkOutStatedFlow.emit(dateTime)
-                            println("체크인 ${this.value}")
-                            println("체크아웃 ${_checkOutStatedFlow.value}")
-                            return@launch
                         }
                         it.isAfter(dateTime) -> {
                             this.emit(dateTime)
                             _checkOutStatedFlow.emit(null)
                             println("체크인 ${this.value}")
                             println("체크아웃 ${_checkOutStatedFlow.value}")
-                            return@launch
                         }
                         else -> {
-                             _checkOutStatedFlow.emit(dateTime)
-                            println("체크인 ${this.value}")
-                            println("체크아웃 ${_checkOutStatedFlow.value}")
-                            return@launch
+                            _checkOutStatedFlow.emit(dateTime)
                         }
                     }
                 } ?: this.emit(dateTime)
-                println("체크인 ${this.value}")
-                println("체크아웃 ${_checkOutStatedFlow.value}")
-                return@launch
             }
         }
     }
-
 
 }

--- a/app/src/main/java/com/example/airbnb/ui/calendar/DayAdapter.kt
+++ b/app/src/main/java/com/example/airbnb/ui/calendar/DayAdapter.kt
@@ -4,10 +4,10 @@ import android.graphics.Color
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
+import com.example.airbnb.R
 import com.example.airbnb.databinding.ItemCalendarDayBinding
 import com.example.airbnb.domain.model.CalendarDay
 import org.joda.time.LocalDate
-import org.joda.time.LocalDateTime
 
 class DayAdapter(private val itemClick: (selectedDate: LocalDate) -> Unit) :
     RecyclerView.Adapter<DayAdapter.ViewHolder>() {
@@ -28,8 +28,8 @@ class DayAdapter(private val itemClick: (selectedDate: LocalDate) -> Unit) :
                 calendarDateToLocalDate = LocalDate(day.year, day.month, day.day.toInt())
 
                 if (day.isSelectable) {
-                    if (day.isStartDay) {
-                        //시작날짜 UI 처리
+                    if (day.isStartDay&&checkIn==null) {
+                        binding.tvCalendarDay.setBackgroundResource(R.drawable.layout_circle_stroke)
                     }
                     binding.selectableColor = Color.BLACK
                 } else {
@@ -41,10 +41,11 @@ class DayAdapter(private val itemClick: (selectedDate: LocalDate) -> Unit) :
                 binding.checkOut = checkOut
 
                 binding.tvCalendarDay.setOnClickListener {
-                   if (day.isSelectable) {
+                    if (day.isSelectable) {
                         itemClick.invoke(calendarDateToLocalDate)
                     }
                 }
+                binding.executePendingBindings()
             }
         }
     }

--- a/app/src/main/java/com/example/airbnb/ui/calendar/DayAdapter.kt
+++ b/app/src/main/java/com/example/airbnb/ui/calendar/DayAdapter.kt
@@ -41,9 +41,10 @@ class DayAdapter(private val itemClick: (selectedDate: LocalDate) -> Unit) :
                 binding.checkOut = checkOut
 
                 binding.tvCalendarDay.setOnClickListener {
-                    itemClick.invoke(calendarDateToLocalDate)
+                   if (day.isSelectable) {
+                        itemClick.invoke(calendarDateToLocalDate)
+                    }
                 }
-                binding.executePendingBindings()
             }
         }
     }
@@ -65,7 +66,7 @@ class DayAdapter(private val itemClick: (selectedDate: LocalDate) -> Unit) :
         this.dayList.addAll(list)
     }
 
-    fun setCheckInAndCheckOut(list: List<CalendarDay>, checkIn: LocalDate?, checkOut: LocalDate?) {
+    fun setCheckInAndCheckOut(checkIn: LocalDate?, checkOut: LocalDate?) {
         this.checkIn = checkIn
         this.checkOut = checkOut
     }

--- a/app/src/main/java/com/example/airbnb/ui/calendar/DayAdapter.kt
+++ b/app/src/main/java/com/example/airbnb/ui/calendar/DayAdapter.kt
@@ -9,31 +9,48 @@ import com.example.airbnb.domain.model.CalendarDay
 import org.joda.time.LocalDate
 import org.joda.time.LocalDateTime
 
-class DayAdapter(private val itemClick: (selectedDate: LocalDate) -> Unit) : RecyclerView.Adapter<DayAdapter.ViewHolder>() {
+class DayAdapter(private val itemClick: (selectedDate: LocalDate) -> Unit) :
+    RecyclerView.Adapter<DayAdapter.ViewHolder>() {
 
     private val dayList = mutableListOf<CalendarDay>()
+    private var checkIn: LocalDate? = null
+    private var checkOut: LocalDate? = null
 
-    class ViewHolder(private val binding: ItemCalendarDayBinding) : RecyclerView.ViewHolder(binding.root) {
-        fun bind(day: CalendarDay, itemClick: (selectedDate:LocalDate) -> Unit) {
+    inner class ViewHolder(private val binding: ItemCalendarDayBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+
+        private lateinit var calendarDateToLocalDate: LocalDate
+
+        fun bind(day: CalendarDay, itemClick: (selectedDate: LocalDate) -> Unit) {
             binding.day = day.day
-            if (day.isSelectable) {
-                if (day.isStartDay) {
-                    //시작날짜 UI 처리
-                }
-                binding.selectableColor= Color.BLACK
-            } else {
-                binding.selectableColor=Color.GRAY
-            }
-            binding.tvCalendarDay.setOnClickListener {
-                itemClick.invoke(LocalDate(day.year, day.month.toInt(), day.day.toInt()))
-            }
 
+            if (day.day.isNotEmpty()) {
+                calendarDateToLocalDate = LocalDate(day.year, day.month, day.day.toInt())
+
+                if (day.isSelectable) {
+                    if (day.isStartDay) {
+                        //시작날짜 UI 처리
+                    }
+                    binding.selectableColor = Color.BLACK
+                } else {
+                    binding.selectableColor = Color.GRAY
+                }
+
+                binding.today = calendarDateToLocalDate
+                binding.checkIn = checkIn
+                binding.checkOut = checkOut
+
+                binding.tvCalendarDay.setOnClickListener {
+                    itemClick.invoke(calendarDateToLocalDate)
+                }
+                binding.executePendingBindings()
+            }
         }
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
         val inflater = LayoutInflater.from(parent.context)
-        return DayAdapter.ViewHolder(ItemCalendarDayBinding.inflate(inflater, parent, false))
+        return ViewHolder(ItemCalendarDayBinding.inflate(inflater, parent, false))
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
@@ -48,8 +65,8 @@ class DayAdapter(private val itemClick: (selectedDate: LocalDate) -> Unit) : Rec
         this.dayList.addAll(list)
     }
 
-    private fun selectDay(selectedDay:LocalDate){
-
-
+    fun setCheckInAndCheckOut(list: List<CalendarDay>, checkIn: LocalDate?, checkOut: LocalDate?) {
+        this.checkIn = checkIn
+        this.checkOut = checkOut
     }
 }

--- a/app/src/main/java/com/example/airbnb/ui/calendar/MonthAdapter.kt
+++ b/app/src/main/java/com/example/airbnb/ui/calendar/MonthAdapter.kt
@@ -8,7 +8,8 @@ import com.example.airbnb.ui.common.CalendarUtil
 import org.joda.time.LocalDate
 import org.joda.time.LocalDateTime
 
-class MonthAdapter(private val itemClick: (selectedDate: LocalDate) -> Unit)  : RecyclerView.Adapter<MonthAdapter.ViewHolder>() {
+class MonthAdapter(private val itemClick: (selectedDate: LocalDate) -> Unit) :
+    RecyclerView.Adapter<MonthAdapter.ViewHolder>() {
 
     private val _monthList = Array(12) { index -> LocalDateTime.now().plusMonths(index) }
     private var checkIn: LocalDate? = null
@@ -26,12 +27,7 @@ class MonthAdapter(private val itemClick: (selectedDate: LocalDate) -> Unit)  : 
 
             val calendarDayList = CalendarUtil.getDayList(dateTime)
             dayAdapter.submitList(calendarDayList)
-
-            if (checkOut != null) {
-                dayAdapter.setCheckInAndCheckOut(calendarDayList, checkIn, checkOut)
-                dayAdapter.notifyDataSetChanged()
-                binding.executePendingBindings()
-            }
+            dayAdapter.setCheckInAndCheckOut(checkIn, checkOut)
         }
     }
 
@@ -49,8 +45,8 @@ class MonthAdapter(private val itemClick: (selectedDate: LocalDate) -> Unit)  : 
     }
 
     fun setCheckInAndCheckOut(checkIn: LocalDate?, checkOut: LocalDate?) {
-            this.checkIn = checkIn
-            this.checkOut = checkOut
+        this.checkIn = checkIn
+        this.checkOut = checkOut
     }
 
 }

--- a/app/src/main/java/com/example/airbnb/ui/calendar/MonthAdapter.kt
+++ b/app/src/main/java/com/example/airbnb/ui/calendar/MonthAdapter.kt
@@ -4,6 +4,7 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.example.airbnb.databinding.ItemCalendarMonthBinding
+import com.example.airbnb.domain.model.CalendarDay
 import com.example.airbnb.ui.common.CalendarUtil
 import org.joda.time.LocalDate
 import org.joda.time.LocalDateTime
@@ -11,7 +12,8 @@ import org.joda.time.LocalDateTime
 class MonthAdapter(private val itemClick: (selectedDate: LocalDate) -> Unit) :
     RecyclerView.Adapter<MonthAdapter.ViewHolder>() {
 
-    private val _monthList = Array(12) { index -> LocalDateTime.now().plusMonths(index) }
+    private val _monthList = mutableListOf<LocalDateTime>()
+    private var calendarMap = mapOf<LocalDateTime, List<CalendarDay>>()
     private var checkIn: LocalDate? = null
     private var checkOut: LocalDate? = null
 
@@ -24,9 +26,9 @@ class MonthAdapter(private val itemClick: (selectedDate: LocalDate) -> Unit) :
                 itemClick.invoke(it)
             }
             binding.rvCalendarMonth.adapter = dayAdapter
-
-            val calendarDayList = CalendarUtil.getDayList(dateTime)
-            dayAdapter.submitList(calendarDayList)
+            calendarMap[dateTime]?.let {
+                dayAdapter.submitList(it)
+            }
             dayAdapter.setCheckInAndCheckOut(checkIn, checkOut)
         }
     }
@@ -47,6 +49,11 @@ class MonthAdapter(private val itemClick: (selectedDate: LocalDate) -> Unit) :
     fun setCheckInAndCheckOut(checkIn: LocalDate?, checkOut: LocalDate?) {
         this.checkIn = checkIn
         this.checkOut = checkOut
+    }
+
+    fun submitCalendarMaps(calendarMap:Map<LocalDateTime, List<CalendarDay>>){
+        this.calendarMap= calendarMap
+        this._monthList.addAll(calendarMap.keys)
     }
 
 }

--- a/app/src/main/java/com/example/airbnb/ui/calendar/MonthAdapter.kt
+++ b/app/src/main/java/com/example/airbnb/ui/calendar/MonthAdapter.kt
@@ -16,8 +16,8 @@ class MonthAdapter(private val itemClick: (selectedDate: LocalDate) -> Unit)  : 
         RecyclerView.ViewHolder(binding.root) {
         fun bind(dateTime: LocalDateTime, itemClick: (selectedDate: LocalDate) -> Unit) {
             binding.tvCalendarMonth.text = dateTime.toDateTime().toString("YYYY년 MM월")
-            val dayAdapter = DayAdapter{
-                 it-> itemClick.invoke(it)
+            val dayAdapter = DayAdapter {
+                itemClick.invoke(it)
             }
             binding.rvCalendarMonth.adapter = dayAdapter
             dayAdapter.submitList(CalendarUtil.getDayList(dateTime))

--- a/app/src/main/java/com/example/airbnb/ui/calendar/MonthAdapter.kt
+++ b/app/src/main/java/com/example/airbnb/ui/calendar/MonthAdapter.kt
@@ -11,31 +11,46 @@ import org.joda.time.LocalDateTime
 class MonthAdapter(private val itemClick: (selectedDate: LocalDate) -> Unit)  : RecyclerView.Adapter<MonthAdapter.ViewHolder>() {
 
     private val _monthList = Array(12) { index -> LocalDateTime.now().plusMonths(index) }
+    private var checkIn: LocalDate? = null
+    private var checkOut: LocalDate? = null
 
-    class ViewHolder(private val binding: ItemCalendarMonthBinding) :
+    inner class ViewHolder(private val binding: ItemCalendarMonthBinding) :
         RecyclerView.ViewHolder(binding.root) {
+
         fun bind(dateTime: LocalDateTime, itemClick: (selectedDate: LocalDate) -> Unit) {
             binding.tvCalendarMonth.text = dateTime.toDateTime().toString("YYYY년 MM월")
             val dayAdapter = DayAdapter {
                 itemClick.invoke(it)
             }
             binding.rvCalendarMonth.adapter = dayAdapter
-            dayAdapter.submitList(CalendarUtil.getDayList(dateTime))
+
+            val calendarDayList = CalendarUtil.getDayList(dateTime)
+            dayAdapter.submitList(calendarDayList)
+
+            if (checkOut != null) {
+                dayAdapter.setCheckInAndCheckOut(calendarDayList, checkIn, checkOut)
+                dayAdapter.notifyDataSetChanged()
+                binding.executePendingBindings()
+            }
         }
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
         val inflater = LayoutInflater.from(parent.context)
-        return MonthAdapter.ViewHolder(ItemCalendarMonthBinding.inflate(inflater, parent, false))
+        return ViewHolder(ItemCalendarMonthBinding.inflate(inflater, parent, false))
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-        holder.bind(_monthList[position],itemClick)
+        holder.bind(_monthList[position], itemClick)
     }
 
     override fun getItemCount(): Int {
         return _monthList.size
     }
 
+    fun setCheckInAndCheckOut(checkIn: LocalDate?, checkOut: LocalDate?) {
+            this.checkIn = checkIn
+            this.checkOut = checkOut
+    }
 
 }

--- a/app/src/main/java/com/example/airbnb/ui/common/CalendarUtil.kt
+++ b/app/src/main/java/com/example/airbnb/ui/common/CalendarUtil.kt
@@ -60,31 +60,3 @@ object CalendarUtil {
         return dayList
     }
 }
-
-//
-//private fun getDayList(date: LocalDate):ArrayList<String> {
-//    val dayLit = arrayListOf<String>()
-//    val yearMonth = YearMonth.from(date)
-//    val lastDay = yearMonth.lengthOfMonth()
-//    val firstDay = date.withDayOfMonth(1)
-//    val dayOfWeek = firstDay.dayOfWeek.value
-//
-//    if (dayOfWeek != 7) {
-//        for (i in 1..42) {
-//            if (i <= dayOfWeek || i > lastDay + dayOfWeek) {
-//                dayLit.add("")
-//            } else {
-//                dayLit.add((i - dayOfWeek).toString())
-//            }
-//        }
-//    } else {
-//        for (i in 8..49) {
-//            if (i <= dayOfWeek || i > lastDay + dayOfWeek) {
-//                dayLit.add("")
-//            } else {
-//                dayLit.add((i - dayOfWeek).toString())
-//            }
-//        }
-//    }
-//    return dayLit
-//}

--- a/app/src/main/java/com/example/airbnb/ui/common/DateBindingAdapter.kt
+++ b/app/src/main/java/com/example/airbnb/ui/common/DateBindingAdapter.kt
@@ -1,5 +1,6 @@
 package com.example.airbnb.ui.common
 
+import android.graphics.Color
 import android.widget.TextView
 import androidx.databinding.BindingAdapter
 import com.example.airbnb.R
@@ -14,5 +15,27 @@ fun displayCheckInDate(view: TextView, dateTime: LocalDate?) {
 @BindingAdapter("checkOutAsString")
 fun displayCheckOutDate(view: TextView, dateTime: LocalDate?) {
     val dateString = dateTime?.toString("MM월 dd일") ?: ""
+    println(dateString)
     view.text = view.context.getString(R.string.checkout_date, dateString)
+}
+
+@BindingAdapter("bindDateString", "checkIn", "checkOut")
+fun displayCheckOutDate(view: TextView, currentDateTime: LocalDate?, checkIn: LocalDate?, checkOut: LocalDate?) {
+    checkOut?.let {
+        checkIn?.let {
+            currentDateTime?.let {
+                if ((it <= checkOut) && (it >= checkIn)) {
+                    view.setBackgroundColor(Color.GRAY)
+                }
+            }
+        }
+    }
+}
+
+@BindingAdapter("bindDateString")
+fun displayDate(view: TextView, dateTime: LocalDate?) {
+    dateTime?.let {
+        val dateString = dateTime.toString("dd")
+        view.text = dateString
+    }
 }

--- a/app/src/main/java/com/example/airbnb/ui/common/DateBindingAdapter.kt
+++ b/app/src/main/java/com/example/airbnb/ui/common/DateBindingAdapter.kt
@@ -2,6 +2,7 @@ package com.example.airbnb.ui.common
 
 import android.graphics.Color
 import android.widget.TextView
+import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.databinding.BindingAdapter
 import com.example.airbnb.R
 import org.joda.time.LocalDate
@@ -14,28 +15,37 @@ fun displayCheckInDate(view: TextView, dateTime: LocalDate?) {
 
 @BindingAdapter("checkOutAsString")
 fun displayCheckOutDate(view: TextView, dateTime: LocalDate?) {
-    val dateString = dateTime?.toString("MM월 dd일") ?: ""
-    println(dateString)
-    view.text = view.context.getString(R.string.checkout_date, dateString)
+    view.text = ""
+    dateTime?.let {
+        val dateString = dateTime.toString("MM월 dd일")
+        view.text = view.context.getString(R.string.checkout_date, dateString)
+    }
 }
 
 @BindingAdapter("bindDateString", "checkIn", "checkOut")
-fun displayCheckOutDate(view: TextView, currentDateTime: LocalDate?, checkIn: LocalDate?, checkOut: LocalDate?) {
-    checkOut?.let {
-        checkIn?.let {
-            currentDateTime?.let {
-                if ((it <= checkOut) && (it >= checkIn)) {
-                    view.setBackgroundColor(Color.GRAY)
-                }
+fun displayCheckOutDate(
+    view: ConstraintLayout,
+    currentDateTime: LocalDate?,
+    checkIn: LocalDate?,
+    checkOut: LocalDate?
+) {
+    currentDateTime?.let {
+        if (checkIn != null && checkOut != null) {
+            if ((it < checkOut) && (it > checkIn)) {
+                view.setBackgroundColor(Color.GRAY)
+            } else if (it == checkIn || it == checkOut) {
+                view.setBackgroundColor(Color.BLUE)
+            } else {
+                view.setBackgroundColor(Color.WHITE)
             }
+        } else if (checkIn != null && checkOut == null) {
+            if (it.isEqual(checkIn)) {
+                view.setBackgroundColor(Color.BLUE)
+            } else {
+                view.setBackgroundColor(Color.WHITE)
+            }
+        } else {
+            view.setBackgroundColor(Color.WHITE)
         }
-    }
-}
-
-@BindingAdapter("bindDateString")
-fun displayDate(view: TextView, dateTime: LocalDate?) {
-    dateTime?.let {
-        val dateString = dateTime.toString("dd")
-        view.text = dateString
-    }
+    } ?: view.setBackgroundColor(Color.WHITE)
 }

--- a/app/src/main/java/com/example/airbnb/ui/common/DateBindingAdapter.kt
+++ b/app/src/main/java/com/example/airbnb/ui/common/DateBindingAdapter.kt
@@ -1,0 +1,18 @@
+package com.example.airbnb.ui.common
+
+import android.widget.TextView
+import androidx.databinding.BindingAdapter
+import com.example.airbnb.R
+import org.joda.time.LocalDate
+
+@BindingAdapter("checkInAsString")
+fun displayCheckInDate(view: TextView, dateTime: LocalDate?) {
+    val dateString = dateTime?.toString("MM월 dd일")
+    view.text = dateString
+}
+
+@BindingAdapter("checkOutAsString")
+fun displayCheckOutDate(view: TextView, dateTime: LocalDate?) {
+    val dateString = dateTime?.toString("MM월 dd일") ?: ""
+    view.text = view.context.getString(R.string.checkout_date, dateString)
+}

--- a/app/src/main/java/com/example/airbnb/ui/common/DateBindingAdapter.kt
+++ b/app/src/main/java/com/example/airbnb/ui/common/DateBindingAdapter.kt
@@ -5,6 +5,7 @@ import android.widget.TextView
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.databinding.BindingAdapter
 import com.example.airbnb.R
+import com.example.airbnb.common.Constants
 import org.joda.time.LocalDate
 
 @BindingAdapter("checkInAsString")
@@ -23,24 +24,19 @@ fun displayCheckOutDate(view: TextView, dateTime: LocalDate?) {
 }
 
 @BindingAdapter("bindDateString", "checkIn", "checkOut")
-fun displayCheckOutDate(
-    view: ConstraintLayout,
-    currentDateTime: LocalDate?,
-    checkIn: LocalDate?,
-    checkOut: LocalDate?
-) {
+fun displayCheckOutDate(view: ConstraintLayout, currentDateTime: LocalDate?, checkIn: LocalDate?, checkOut: LocalDate?) {
     currentDateTime?.let {
         if (checkIn != null && checkOut != null) {
             if ((it < checkOut) && (it > checkIn)) {
-                view.setBackgroundColor(Color.GRAY)
+                view.setBackgroundColor(Constants.CALENDAR_IN_RANGE_COLOR)
             } else if (it == checkIn || it == checkOut) {
-                view.setBackgroundColor(Color.BLUE)
+                view.setBackgroundResource(R.drawable.layout_circle_grey_background)
             } else {
                 view.setBackgroundColor(Color.WHITE)
             }
         } else if (checkIn != null && checkOut == null) {
             if (it.isEqual(checkIn)) {
-                view.setBackgroundColor(Color.BLUE)
+                view.setBackgroundResource(R.drawable.layout_circle_grey_background)
             } else {
                 view.setBackgroundColor(Color.WHITE)
             }

--- a/app/src/main/java/com/example/airbnb/ui/home/SearchFragment.kt
+++ b/app/src/main/java/com/example/airbnb/ui/home/SearchFragment.kt
@@ -8,6 +8,9 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
+import androidx.navigation.NavController
+import androidx.navigation.Navigation
+import com.example.airbnb.R
 import com.example.airbnb.databinding.FragmentSearchBinding
 import com.example.airbnb.domain.model.NearDestination
 import com.example.airbnb.domain.model.SearchResultDestination
@@ -17,7 +20,7 @@ import com.example.airbnb.ui.common.switchFromCustomModeToClearText
 class SearchFragment : Fragment() {
 
     private lateinit var binding: FragmentSearchBinding
-
+    private lateinit var navigator: NavController
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -30,7 +33,10 @@ class SearchFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         val adapter = NearTravelDestinationAdapter()
-        val searchAdapter = SearchResultAdapter()
+        val searchAdapter = SearchResultAdapter{
+            moveToInformationInputPage()
+        }
+        navigator = Navigation.findNavController(view)
         binding.rvSearchNearTravelDestination.adapter = adapter
         binding.rvSearchResultDestination.adapter = searchAdapter
         adapter.submitNearDestinations(makeDummyNearDestinations())
@@ -83,4 +89,7 @@ class SearchFragment : Fragment() {
         binding.etlSearch.switchFromCustomModeToClearText(requireContext())
     }
 
+    private fun moveToInformationInputPage() {
+        navigator.navigate(R.id.action_searchFragment_to_informationInputFragment)
+    }
 }

--- a/app/src/main/java/com/example/airbnb/ui/home/SearchResultAdapter.kt
+++ b/app/src/main/java/com/example/airbnb/ui/home/SearchResultAdapter.kt
@@ -7,8 +7,9 @@ import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.example.airbnb.databinding.ItemSearchResultDestinationBinding
 import com.example.airbnb.domain.model.SearchResultDestination
+import org.joda.time.LocalDate
 
-class SearchResultAdapter : ListAdapter<SearchResultDestination, SearchResultAdapter.ViewHolder>(SearchResultDiffUtil) {
+class SearchResultAdapter(private val itemClick: () -> Unit)  : ListAdapter<SearchResultDestination, SearchResultAdapter.ViewHolder>(SearchResultDiffUtil) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
         val inflater = LayoutInflater.from(parent.context)
@@ -16,14 +17,19 @@ class SearchResultAdapter : ListAdapter<SearchResultDestination, SearchResultAda
     }
 
     override fun onBindViewHolder(holder: SearchResultAdapter.ViewHolder, position: Int) {
-        holder.bind(getItem(position))
+        holder.bind(getItem(position),itemClick)
     }
 
     class ViewHolder(private val binding: ItemSearchResultDestinationBinding) :
         RecyclerView.ViewHolder(binding.root) {
 
-        fun bind(destination: SearchResultDestination) {
+        fun bind(destination: SearchResultDestination, itemClick: () -> Unit) {
             binding.destination = destination
+            binding.clSearchResult.setOnClickListener {
+                // 검색된 결과중 하나 클릭시 정보입력 페이지로 이동
+                itemClick.invoke()
+            }
+
         }
     }
 

--- a/app/src/main/java/com/example/airbnb/ui/login/LoginFragment.kt
+++ b/app/src/main/java/com/example/airbnb/ui/login/LoginFragment.kt
@@ -33,10 +33,6 @@ class LoginFragment : Fragment() {
             navigator.navigate(R.id.action_loginFragment_to_homeFragment)
         }
 
-        binding.btnLoginGithub.setOnClickListener {
-            //화면 이동 구현
-            navigator.navigate(R.id.action_loginFragment_to_informationInputFragment2)
-        }
 
     }
 

--- a/app/src/main/java/com/example/airbnb/ui/priceRange/PriceRangeFragment.kt
+++ b/app/src/main/java/com/example/airbnb/ui/priceRange/PriceRangeFragment.kt
@@ -1,0 +1,21 @@
+package com.example.airbnb.ui.priceRange
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import com.example.airbnb.R
+
+
+class PriceRangeFragment : Fragment() {
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        // Inflate the layout for this fragment
+        return inflater.inflate(R.layout.fragment_price_range, container, false)
+    }
+
+}

--- a/app/src/main/res/drawable/layout_circle_grey_background.xml
+++ b/app/src/main/res/drawable/layout_circle_grey_background.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/grey1" />
+    <corners  android:radius="350dp"  />
+</shape>

--- a/app/src/main/res/drawable/layout_circle_stroke.xml
+++ b/app/src/main/res/drawable/layout_circle_stroke.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/white" />
+    <stroke android:color="@color/grey3" android:width="1dp"/>
+    <corners  android:radius="250dp"  />
+</shape>

--- a/app/src/main/res/layout/fragment_calendar.xml
+++ b/app/src/main/res/layout/fragment_calendar.xml
@@ -5,6 +5,14 @@
 
     <data>
 
+        <variable
+            name="checkIn"
+            type="org.joda.time.LocalDate" />
+
+        <variable
+            name="checkOut"
+            type="org.joda.time.LocalDate" />
+
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -38,7 +46,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="8dp"
                 android:paddingBottom="22dp"
-                android:text="5월 26일 "
+                checkInAsString="@{checkIn}"
                 app:layout_constraintStart_toStartOf="@id/tv_information_title"
                 app:layout_constraintTop_toBottomOf="@id/tv_information_title"
                 app:layout_constraintBottom_toBottomOf="parent"
@@ -50,7 +58,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="8dp"
                 android:paddingBottom="22dp"
-                android:text=" - 6월 10일"
+                checkOutAsString="@{checkOut}"
                 app:layout_constraintStart_toEndOf="@id/tv_information_range_start"
                 app:layout_constraintTop_toBottomOf="@id/tv_information_title"
                 app:layout_constraintBottom_toBottomOf="parent"

--- a/app/src/main/res/layout/fragment_information_input.xml
+++ b/app/src/main/res/layout/fragment_information_input.xml
@@ -22,10 +22,12 @@
             app:layout_constraintTop_toTopOf="parent" />
 
         <ImageButton
+            android:id="@+id/iBtn_information_next"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginEnd="24dp"
             android:background="@drawable/ic_check"
+            android:backgroundTint="@color/tab_selector_icon"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="@id/iBtn_information_back" />
 

--- a/app/src/main/res/layout/fragment_price_range.xml
+++ b/app/src/main/res/layout/fragment_price_range.xml
@@ -5,27 +5,19 @@
 
     <data>
 
-        <variable
-            name="checkIn"
-            type="org.joda.time.LocalDate" />
-
-        <variable
-            name="checkOut"
-            type="org.joda.time.LocalDate" />
-
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        tools:context=".ui.calendar.CalendarFragment">
+        tools:context=".ui.priceRange.PriceRangeFragment">
 
         <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/cl_calendar_header"
+            android:id="@+id/cl_price_range_header"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            app:layout_constraintStart_toStartOf="parent"
             android:background="@color/grey_scale_off_white"
+            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent">
 
             <TextView
@@ -35,7 +27,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginStart="76dp"
                 android:layout_marginTop="34dp"
-                android:text="@string/tv_calendar_title"
+                android:text="@string/tv_price_range_title"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
 
@@ -46,11 +38,11 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="8dp"
                 android:paddingBottom="22dp"
-                checkInAsString="@{checkIn}"
-                app:layout_constraintStart_toStartOf="@id/tv_information_title"
-                app:layout_constraintTop_toBottomOf="@id/tv_information_title"
+                android:text="$100"
                 app:layout_constraintBottom_toBottomOf="parent"
-                />
+                app:layout_constraintStart_toStartOf="@id/tv_information_title"
+                app:layout_constraintTop_toBottomOf="@id/tv_information_title" />
+
             <TextView
                 android:id="@+id/tv_information_range_end"
                 style="@style/HeadLine6.Black"
@@ -58,41 +50,35 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="8dp"
                 android:paddingBottom="22dp"
-                checkOutAsString="@{checkOut}"
-                app:layout_constraintStart_toEndOf="@id/tv_information_range_start"
-                app:layout_constraintTop_toBottomOf="@id/tv_information_title"
+                android:text="-$10000"
                 app:layout_constraintBottom_toBottomOf="parent"
-                />
+                app:layout_constraintStart_toEndOf="@id/tv_information_range_start"
+                app:layout_constraintTop_toBottomOf="@id/tv_information_title" />
         </androidx.constraintlayout.widget.ConstraintLayout>
 
-        <TextView
-            android:id="@+id/tv_calendar_week"
-            style="@style/Subtitle2"
-            android:layout_width="0dp"
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginHorizontal="12dp"
-            android:layout_marginTop="16dp"
-            android:layout_marginBottom="4dp"
-            android:letterSpacing="3"
-            android:text="일월화수목금토"
-            app:layout_constraintEnd_toEndOf="parent"
+            android:paddingHorizontal="16dp"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/cl_calendar_header" />
+            app:layout_constraintTop_toBottomOf="@id/cl_price_range_header">
 
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/rv_calendar"
-            android:layout_width="0dp"
-            android:layout_height="0dp"
-            android:orientation="vertical"
-            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/tv_calendar_week"
-            tools:listitem="@layout/item_calendar_month" />
+            <TextView
+                android:id="@+id/tv_price_range_average_price"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:text="평균 1박요금은 $원입니다"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintStart_toStartOf="parent" />
 
+            <com.stfalcon.pricerangebar.RangeBarWithChart
 
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/tv_price_range_average_price" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>
-
-

--- a/app/src/main/res/layout/item_calendar_day.xml
+++ b/app/src/main/res/layout/item_calendar_day.xml
@@ -26,6 +26,7 @@
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/cl_calendar_day"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         bindDateString="@{today}"
@@ -36,10 +37,10 @@
             android:id="@+id/tv_calendar_day"
             style="@style/Subtitle2"
             android:text="@{day}"
-            android:layout_width="0dp"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginHorizontal="12dp"
             android:gravity="center"
+            android:paddingHorizontal="12dp"
             android:paddingVertical="14dp"
             android:textColor="@{selectableColor}"
             app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/item_calendar_day.xml
+++ b/app/src/main/res/layout/item_calendar_day.xml
@@ -27,14 +27,14 @@
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="wrap_content"
+        bindDateString="@{today}"
+        checkIn="@{checkIn}"
+        checkOut="@{checkOut}">
 
         <TextView
             android:id="@+id/tv_calendar_day"
             style="@style/Subtitle2"
-            bindDateString="@{today}"
-            checkIn="@{checkIn}"
-            checkOut="@{checkOut}"
             android:text="@{day}"
             android:layout_width="0dp"
             android:layout_height="wrap_content"

--- a/app/src/main/res/layout/item_calendar_day.xml
+++ b/app/src/main/res/layout/item_calendar_day.xml
@@ -3,9 +3,22 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <data>
+
         <variable
             name="day"
             type="String" />
+
+        <variable
+            name="today"
+            type="org.joda.time.LocalDate" />
+
+        <variable
+            name="checkIn"
+            type="org.joda.time.LocalDate" />
+
+        <variable
+            name="checkOut"
+            type="org.joda.time.LocalDate" />
 
         <variable
             name="selectableColor"
@@ -19,13 +32,16 @@
         <TextView
             android:id="@+id/tv_calendar_day"
             style="@style/Subtitle2"
+            bindDateString="@{today}"
+            checkIn="@{checkIn}"
+            checkOut="@{checkOut}"
+            android:text="@{day}"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="12dp"
             android:gravity="center"
             android:paddingVertical="14dp"
-            android:text="@{day}"
-            android:textColor= "@{selectableColor}"
+            android:textColor="@{selectableColor}"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />

--- a/app/src/main/res/layout/item_search_result_destination.xml
+++ b/app/src/main/res/layout/item_search_result_destination.xml
@@ -11,6 +11,7 @@
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/cl_search_result"
         android:layout_width="274dp"
         android:layout_height="wrap_content"
         android:layout_marginEnd="16dp"

--- a/app/src/main/res/navigation/navigation_information.xml
+++ b/app/src/main/res/navigation/navigation_information.xml
@@ -9,5 +9,13 @@
         android:id="@+id/calendarFragment"
         android:name="com.example.airbnb.ui.calendar.CalendarFragment"
         android:label="fragment_calendar"
-        tools:layout="@layout/fragment_calendar" />
+        tools:layout="@layout/fragment_calendar" >
+        <action
+            android:id="@+id/action_calendarFragment_to_priceRangeFragment"
+            app:destination="@id/priceRangeFragment" />
+    </fragment>
+    <fragment
+        android:id="@+id/priceRangeFragment"
+        android:name="com.example.airbnb.ui.priceRange.PriceRangeFragment"
+        android:label="PriceRangeFragment" />
 </navigation>

--- a/app/src/main/res/navigation/navigation_main.xml
+++ b/app/src/main/res/navigation/navigation_main.xml
@@ -13,9 +13,6 @@
         <action
             android:id="@+id/action_loginFragment_to_homeFragment"
             app:destination="@id/homeFragment" />
-        <action
-            android:id="@+id/action_loginFragment_to_informationInputFragment2"
-            app:destination="@id/informationInputFragment" />
     </fragment>
     <fragment
         android:id="@+id/homeFragment"
@@ -29,7 +26,11 @@
     <fragment
         android:id="@+id/searchFragment"
         android:name="com.example.airbnb.ui.home.SearchFragment"
-        android:label="SearchFragment" />
+        android:label="SearchFragment" >
+        <action
+            android:id="@+id/action_searchFragment_to_informationInputFragment"
+            app:destination="@id/informationInputFragment" />
+    </fragment>
     <fragment
         android:id="@+id/informationInputFragment"
         android:name="com.example.airbnb.ui.information.InformationInputFragment"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,6 +12,8 @@
     <string name="tv_home_recommend_title">어디에서나, 여행은\n살아보는거야!</string>
     <string name="search_bar_hint">어디로 여행하세요?</string>
     <string name="search_near_travel_destination">근처의 인기 여행지</string>
+    <string name="checkout_date">-%s</string>
     <!-- TODO: Remove or change this placeholder text -->
     <string name="hello_blank_fragment">Hello blank fragment</string>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,5 +17,7 @@
     <string name="skip_btn_title">건너뛰기</string>
     <!-- TODO: Remove or change this placeholder text -->
     <string name="hello_blank_fragment">Hello blank fragment</string>
+    <string name="tv_calendar_title">여행일정</string>
+    <string name="tv_price_range_title">가격범위</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,6 +13,8 @@
     <string name="search_bar_hint">어디로 여행하세요?</string>
     <string name="search_near_travel_destination">근처의 인기 여행지</string>
     <string name="checkout_date">-%s</string>
+    <string name="erase_btn_title">지우기</string>
+    <string name="skip_btn_title">건너뛰기</string>
     <!-- TODO: Remove or change this placeholder text -->
     <string name="hello_blank_fragment">Hello blank fragment</string>
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -10,6 +10,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        maven { url 'https://jitpack.io' }
     }
 }
 rootProject.name = "airbnb"


### PR DESCRIPTION

## OverView
- 콜백 함수를 통해 선택한 날짜를 ViewModel 에서 각각 분기 처리
- flow 를 통해 분기된 체크인, 체크아웃 날짜 데이터를 BindingAdapter 를 통해 화면에 표시
- BindingAdapter를 통해 날짜 선택했을 때 배경색 변경 완료
- 각 어댑터의 메서드 호출을 통해 ViewModel 에서 생성한 체크인, 체크아웃 LocalDate 객체 전달
- 체크인/체크아웃 날짜 선택시 UI 변경 로직 완성 ( UI 변경을 위해 drawble 파일 정의)
- 선택가능한 날짜중 가장 첫날짜 UI 변경 로직 적용
- 하단 건너뛰기/ 지우기 버튼 로직 구현 (checkIn/checkOut 값 입력여부에 따라 활성화/비활성화)
- 상단 체크버튼 로직 구현 ( 모든 값 입력시 selected=true로 설정)
- 기존 테스트를 위해 로그인에서 정보 입력화면으로 넘어갔던 부분을 검색화면에서 넘어가도록 수정
- 검색화면에서 검색결과의 각 아이템에 클릭 리스너를 등록, 클릭시 정보입력 페이지로 이동하도록 구현
- 달력 화면에 체크버튼클릭시 가격페이지 이동 로직 완성
- 가격 페이지에 PriceRangeSeekBar 뷰추가