### PR TITLE
[Android][라이너스_히데] 실제 Api 서버와 통신 및 숙소 상세 페이지 데이터 바인딩 완료

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'com.android.application'
     id 'org.jetbrains.kotlin.android'
     id 'kotlin-kapt'
+    id 'kotlin-parcelize'
 }
 
 def Properties properties = new Properties()

--- a/android/app/src/main/java/com/example/airbnb/data/dto/SearchAccommodation.kt
+++ b/android/app/src/main/java/com/example/airbnb/data/dto/SearchAccommodation.kt
@@ -78,4 +78,4 @@ data class Content(
     val roomName: String
 )
 
-fun Content.toSearchResultAccommodation(): SearchResultAccommodation = SearchResultAccommodation(image,true, roomName,averageRating.toFloat(), commentNumber, oneDayPerPrice.toInt()  )
+fun Content.toSearchResultAccommodation(): SearchResultAccommodation = SearchResultAccommodation(accommodationId, image,true, roomName,averageRating.toFloat(), commentNumber, oneDayPerPrice.toInt()  )

--- a/android/app/src/main/java/com/example/airbnb/data/dto/SearchAccommodationByConditionResultDto.kt
+++ b/android/app/src/main/java/com/example/airbnb/data/dto/SearchAccommodationByConditionResultDto.kt
@@ -21,4 +21,4 @@ data class SearchAccommodationByConditionResultDtoItem(
     val roomName: String
 )
 
-fun SearchAccommodationByConditionResultDtoItem.toSearchResultAccommodation(): SearchResultAccommodation = SearchResultAccommodation(imageUrl,true, roomName,averageRating.toFloat(), commentCount, oneDayPerPrice  )
+fun SearchAccommodationByConditionResultDtoItem.toSearchResultAccommodation(): SearchResultAccommodation = SearchResultAccommodation(accommodationId, imageUrl,true, roomName,averageRating.toFloat(), commentCount, oneDayPerPrice  )

--- a/android/app/src/main/java/com/example/airbnb/data/dto/SearchAccommodationResultDto.kt
+++ b/android/app/src/main/java/com/example/airbnb/data/dto/SearchAccommodationResultDto.kt
@@ -9,7 +9,7 @@ class SearchAccommodationResultDto : ArrayList<SearchAccommodationResultDtoItem>
 
 data class SearchAccommodationResultDtoItem(
     @SerializedName("accommodationId")
-    val accommodationId: Int?,
+    val accommodationId: Int,
     @SerializedName("accommodationType")
     val accommodationType: String?,
     @SerializedName("address")
@@ -26,4 +26,4 @@ data class SearchAccommodationResultDtoItem(
     val roomName: String
 )
 
-fun SearchAccommodationResultDtoItem.toSearchResultAccommodation():SearchResultAccommodation = SearchResultAccommodation(image,true, roomName,averageRating.toFloat(), commentNumber, oneDayPerPrice  )
+fun SearchAccommodationResultDtoItem.toSearchResultAccommodation():SearchResultAccommodation = SearchResultAccommodation(accommodationId, image,true, roomName,averageRating.toFloat(), commentNumber, oneDayPerPrice  )

--- a/android/app/src/main/java/com/example/airbnb/data/remote/accommodationDetail/AccommodationDetailApi.kt
+++ b/android/app/src/main/java/com/example/airbnb/data/remote/accommodationDetail/AccommodationDetailApi.kt
@@ -7,6 +7,6 @@ import retrofit2.http.Path
 interface AccommodationDetailApi {
 
     @GET("accommodations/{id}")
-    suspend fun getAccommodationDetail(@Path("id") accommodationId: Int = 1): AccommodationDetailDto
+    suspend fun getAccommodationDetail(@Path("id") accommodationId: Int): AccommodationDetailDto
 
 }

--- a/android/app/src/main/java/com/example/airbnb/data/remote/accommodationDetail/AccommodationDetailRemoteDataSource.kt
+++ b/android/app/src/main/java/com/example/airbnb/data/remote/accommodationDetail/AccommodationDetailRemoteDataSource.kt
@@ -5,6 +5,6 @@ import com.example.airbnb.data.dto.AccommodationDetailDto
 class AccommodationDetailRemoteDataSource(private val api: AccommodationDetailApi) : AccommodationDetailDataSource {
 
     override suspend fun getAccommodationDetail(accommodationId: Int): AccommodationDetailDto {
-        return api.getAccommodationDetail()
+        return api.getAccommodationDetail(accommodationId)
     }
 }

--- a/android/app/src/main/java/com/example/airbnb/domain/model/SearchCondition.kt
+++ b/android/app/src/main/java/com/example/airbnb/domain/model/SearchCondition.kt
@@ -1,26 +1,66 @@
 package com.example.airbnb.domain.model
 
+import android.os.Parcel
+import android.os.Parcelable
+
 data class SearchCondition(
-    val searchTag:String,
-    val checkInDate:String="",
-    val checkOutDate:String="",
-    val minPrice:Int= 0,
-    val maxPrice:Int =0,
-    val adultCount:Int=0,
-    val childCount:Int=0,
-    val toddlerCount:Int=0
-)
+    val searchTag: String,
+    val checkInDate: String = "",
+    val checkOutDate: String = "",
+    val minPrice: Int = 0,
+    val maxPrice: Int = 0,
+    val adultCount: Int = 0,
+    val childCount: Int = 0,
+    val toddlerCount: Int = 0
+) : Parcelable {
+    constructor(parcel: Parcel) : this(
+        parcel.readString() ?: "",
+        parcel.readString() ?: "",
+        parcel.readString() ?: "",
+        parcel.readInt(),
+        parcel.readInt(),
+        parcel.readInt(),
+        parcel.readInt(),
+        parcel.readInt()
+    ) {
+    }
+
+    override fun writeToParcel(parcel: Parcel, flags: Int) {
+        parcel.writeString(searchTag)
+        parcel.writeString(checkInDate)
+        parcel.writeString(checkOutDate)
+        parcel.writeInt(minPrice)
+        parcel.writeInt(maxPrice)
+        parcel.writeInt(adultCount)
+        parcel.writeInt(childCount)
+        parcel.writeInt(toddlerCount)
+    }
+
+    override fun describeContents(): Int {
+        return 0
+    }
+
+    companion object CREATOR : Parcelable.Creator<SearchCondition> {
+        override fun createFromParcel(parcel: Parcel): SearchCondition {
+            return SearchCondition(parcel)
+        }
+
+        override fun newArray(size: Int): Array<SearchCondition?> {
+            return arrayOfNulls(size)
+        }
+    }
+}
 
 
 fun SearchCondition.toQueryMap(): MutableMap<String, String> {
-    val queryMap : MutableMap<String, String> = mutableMapOf()
-    queryMap["tagName"]= searchTag
-    queryMap["checkInt"]= checkInDate
-    queryMap["checkOut"]= checkOutDate
-    queryMap["minPrice"]= minPrice.toString()
-    queryMap["maxPrice"]= maxPrice.toString()
+    val queryMap: MutableMap<String, String> = mutableMapOf()
+    queryMap["tagName"] = searchTag
+    queryMap["checkInt"] = checkInDate
+    queryMap["checkOut"] = checkOutDate
+    queryMap["minPrice"] = minPrice.toString()
+    queryMap["maxPrice"] = maxPrice.toString()
     queryMap["adults"] = adultCount.toString()
-    queryMap["children"]= childCount.toString()
+    queryMap["children"] = childCount.toString()
     queryMap["infants"] = toddlerCount.toString()
     return queryMap
 }

--- a/android/app/src/main/java/com/example/airbnb/domain/model/SearchResultAccommodation.kt
+++ b/android/app/src/main/java/com/example/airbnb/domain/model/SearchResultAccommodation.kt
@@ -1,9 +1,10 @@
 package com.example.airbnb.domain.model
 
 data class SearchResultAccommodation(
-    val imageUrl:String = "",
+    val accommodationID: Int = 0,
+    val imageUrl: String = "",
     val superHost: Boolean = true,
-    val name:String="",
+    val name: String? = "",
     val reviewAverage: Float = 0.0F,
     val reviewCount : Int = 0,
     val payPerNight :Int = 0,

--- a/android/app/src/main/java/com/example/airbnb/ui/accommodationDetail/AccommodationDetailActivity.kt
+++ b/android/app/src/main/java/com/example/airbnb/ui/accommodationDetail/AccommodationDetailActivity.kt
@@ -2,39 +2,44 @@ package com.example.airbnb.ui.accommodationDetail
 
 import android.content.Intent
 import android.os.Bundle
-import android.util.Log
 import androidx.appcompat.app.AppCompatActivity
+import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.view.isVisible
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
+import androidx.viewpager2.widget.ViewPager2
 import com.example.airbnb.R
-import com.example.airbnb.databinding.ActivityAccommodationBinding
+import com.example.airbnb.databinding.ActivityAccommodationDetailBinding
+import com.example.airbnb.domain.model.SearchCondition
 import com.example.airbnb.ui.reservationInformation.ReservationInformation
 import kotlinx.coroutines.launch
 import org.koin.android.ext.android.inject
 
 class AccommodationDetailActivity : AppCompatActivity() {
 
-    private lateinit var binding: ActivityAccommodationBinding
+    private lateinit var binding: ActivityAccommodationDetailBinding
     private lateinit var accommodationDetailAdapter: AccommodationDetailAdapter
     private val viewModel: AccommodationDetailViewModel by inject()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        binding = DataBindingUtil.setContentView(this, R.layout.activity_accommodation)
+        binding = DataBindingUtil.setContentView(this, R.layout.activity_accommodation_detail)
+        binding.lifecycleOwner = this
         setContentView(binding.root)
+
         accommodationDetailAdapter = AccommodationDetailAdapter()
         binding.vpAccommodation.adapter = accommodationDetailAdapter
 
+        setViewPagerListener()
         binding.btnAccommodationDetailReservation.setOnClickListener {
             showReservationDialog()
         }
-        viewModel.loadAccommodationDetail()
 
-        binding.clAccommodationDetailReservation.isVisible = false
-        binding.clAccommodationDetailInputInformation.isVisible = true
+        loadAccommodationDetailInfo()
+        loadAccommodationCondition()
+
 
         binding.btnAccommodationDetailInputInformation.setOnClickListener {
             moveToReservationInformationActivity()
@@ -43,10 +48,14 @@ class AccommodationDetailActivity : AppCompatActivity() {
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
                 launch { loadAccommodationDetail() }
+                launch { validateCondition() }
             }
         }
+    }
 
-
+    private fun loadAccommodationDetailInfo() {
+        val savedAccommodationID = intent.getIntExtra("id", 1)
+        viewModel.loadAccommodationDetail(savedAccommodationID)
     }
 
     private fun showReservationDialog() {
@@ -67,4 +76,40 @@ class AccommodationDetailActivity : AppCompatActivity() {
             }
         }
     }
+
+    private suspend fun validateCondition() {
+        viewModel.accommodationCondition.collect {
+            it?.let {
+                binding.accommodationCondition = it
+                showLayout(it.checkOutDate)
+            }
+        }
+    }
+
+    private fun loadAccommodationCondition() {
+        val savedAccommodationCondition = intent.getParcelableExtra<SearchCondition>("condition")
+        savedAccommodationCondition?.let {
+            viewModel.setAccommodationCondition(savedAccommodationCondition)
+        }
+    }
+
+    private fun setViewPagerListener() {
+        // 페이지 리스너 달아보기
+        binding.vpAccommodation.registerOnPageChangeCallback(object :
+            ViewPager2.OnPageChangeCallback() {
+            override fun onPageSelected(position: Int) {
+                super.onPageSelected(position)
+                binding.viewPagerCurrentPage = position + 1
+            }
+        })
+    }
+
+    private fun showLayout(checkOut: String) {
+        binding.clAccommodationDetailReservation.isVisible =
+            checkOut.isNotEmpty() && checkOut.isNotBlank()
+        binding.clAccommodationDetailInputInformation.isVisible =
+            !(checkOut.isNotEmpty() && checkOut.isNotBlank())
+    }
+
+
 }

--- a/android/app/src/main/java/com/example/airbnb/ui/accommodationDetail/AccommodationDetailViewModel.kt
+++ b/android/app/src/main/java/com/example/airbnb/ui/accommodationDetail/AccommodationDetailViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.airbnb.domain.AccommodationDetailRepository
 import com.example.airbnb.domain.model.AccommodationDetailItem
+import com.example.airbnb.domain.model.SearchCondition
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
@@ -14,10 +15,19 @@ class AccommodationDetailViewModel(private val accommodationDetailRepository: Ac
     private val _accommodationDetailStateFlow = MutableStateFlow<AccommodationDetailItem?>(null)
     val accommodationDetailStateFlow = _accommodationDetailStateFlow.asStateFlow()
 
+    private val _accommodationCondition = MutableStateFlow<SearchCondition?>(null)
+    val accommodationCondition = _accommodationCondition.asStateFlow()
 
-    fun loadAccommodationDetail(accommodationId: Int = 1) {
+
+    fun loadAccommodationDetail(accommodationId: Int) {
         viewModelScope.launch {
             _accommodationDetailStateFlow.emit(accommodationDetailRepository.getAccommodationDetail(accommodationId))
+        }
+    }
+
+    fun setAccommodationCondition(condition: SearchCondition) {
+        viewModelScope.launch {
+            _accommodationCondition.emit(condition)
         }
     }
 }

--- a/android/app/src/main/java/com/example/airbnb/ui/common/AccommodationDetailBindingAdapter.kt
+++ b/android/app/src/main/java/com/example/airbnb/ui/common/AccommodationDetailBindingAdapter.kt
@@ -1,0 +1,56 @@
+package com.example.airbnb.ui.common
+
+import android.widget.TextView
+import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.core.view.isVisible
+import androidx.databinding.BindingAdapter
+import com.example.airbnb.R
+import java.text.DecimalFormat
+
+
+@BindingAdapter("bindViewPagerCurrentPage", "bindViewPagerTap")
+fun bindViewPagerTapNumber(view: TextView, currentPage: Int?, list: List<String>?) {
+    view.text = view.context.getString(R.string.accommodation_detail_view_pager_number, currentPage, list?.size)
+}
+
+@BindingAdapter("bindRatings", "bindComments")
+fun bindRating(view: TextView, averageRating: Double?, commentSize: Int?) {
+    val ratingString = averageRating.toString()
+    view.text = view.context.getString(R.string.accommodation_detail_rating_comments, ratingString, commentSize)
+}
+
+@BindingAdapter("bindHostName")
+fun bindHostName(view: TextView, host: String?) {
+    view.text = view.context.getString(R.string.accommodation_detail_host, host)
+}
+
+@BindingAdapter("bindMaxPeople", "bindBedRooms", "bindBeds", "bindBathRooms")
+fun bindRooms(view: TextView, maxNumberOfPeople: Int?, bedRooms: Int?, beds: Int?, bathRooms: Int?) {
+    view.text = view.context.getString(R.string.accommodation_detail_rooms_detail, maxNumberOfPeople, bedRooms, beds, bathRooms)
+}
+
+@BindingAdapter("bindOneDayPrice")
+fun bindOneDayPrice(view: TextView, oneDayPerPrice: Int?) {
+    val formatter = DecimalFormat("#,###")
+    val price = formatter.format(oneDayPerPrice)
+    view.text = view.context.getString(R.string.accommodation_detail_one_day_price, price)
+}
+
+@BindingAdapter("bindReservationCheckIn", "bindReservationCheckOut")
+fun bindCheckInCheckOut(view: TextView, checkIn: String?, checkOut: String?) {
+    view.text = view.context.getString(R.string.accommodation_detail_checkin_checkout, checkIn, checkOut)
+}
+
+@BindingAdapter("showLayout", "isReservationLayout")
+fun showLayout(view: ConstraintLayout, checkOut: String?, isReservationLayout: Boolean?) {
+    if (checkOut != null && isReservationLayout != null) {
+        if (isReservationLayout) {
+            view.isVisible = checkOut.isNotEmpty() && checkOut.isNotBlank()
+        } else {
+            view.isVisible = !(checkOut.isNotEmpty() && checkOut.isNotBlank())
+        }
+    }
+}
+
+
+

--- a/android/app/src/main/java/com/example/airbnb/ui/mapSearch/MapSearchActivity.kt
+++ b/android/app/src/main/java/com/example/airbnb/ui/mapSearch/MapSearchActivity.kt
@@ -53,7 +53,7 @@ class MapSearchActivity : AppCompatActivity() {
     private fun getSearchResultAccommodations():List<SearchResultAccommodation>{
         val accommodations = mutableListOf<SearchResultAccommodation>()
         for(i in 0..100){
-            accommodations.add(SearchResultAccommodation("dummy Image", true,"서울 왕십리 게스트하우스"))
+            accommodations.add(SearchResultAccommodation(1, "dummy Image", true,"서울 왕십리 게스트하우스"))
         }
         return accommodations
     }

--- a/android/app/src/main/java/com/example/airbnb/ui/searchResult/SearchResultAdapter.kt
+++ b/android/app/src/main/java/com/example/airbnb/ui/searchResult/SearchResultAdapter.kt
@@ -14,7 +14,7 @@ import com.example.airbnb.domain.model.SearchResultProgressBar
 const val VIEW_TYPE_LOADING = 0
 const val VIEW_TYPE_ITEM = 1
 
-class SearchResultAdapter(private val itemClick: () -> Unit, private val conditionClick:()->Unit) : RecyclerView.Adapter<RecyclerView.ViewHolder>(){
+class SearchResultAdapter(private val itemClick: (Int) -> Unit, private val conditionClick:(Int)->Unit) : RecyclerView.Adapter<RecyclerView.ViewHolder>(){
 
     private val items= mutableListOf<SearchResult>()
 
@@ -50,14 +50,15 @@ class SearchResultAdapter(private val itemClick: () -> Unit, private val conditi
     inner class ItemViewHolder(private val binding: ItemSearchResultAccommodationBinding) :
         RecyclerView.ViewHolder(binding.root) {
 
-        fun bind(accommodation: SearchResultAccommodation, itemClick: () -> Unit, conditionClick: () -> Unit) {
+        fun bind(accommodation: SearchResultAccommodation, itemClick: (accommodationID: Int) -> Unit, conditionClick: (accommodationID: Int) -> Unit) {
             binding.accommodation= accommodation
             binding.tvSearchResultHostInfo.isVisible= accommodation.superHost
+
             binding.iBtnWish.setOnClickListener {
-                conditionClick.invoke()
+                conditionClick.invoke(accommodation.accommodationID)
             }
             binding.root.setOnClickListener {
-                itemClick.invoke()
+                itemClick.invoke(accommodation.accommodationID)
             }
 
         }

--- a/android/app/src/main/java/com/example/airbnb/ui/searchResult/SearchResultFragment.kt
+++ b/android/app/src/main/java/com/example/airbnb/ui/searchResult/SearchResultFragment.kt
@@ -1,9 +1,11 @@
 package com.example.airbnb.ui.searchResult
 
 import android.os.Bundle
+import android.os.Parcelable
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.os.bundleOf
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
 import androidx.navigation.NavController
@@ -23,21 +25,25 @@ class SearchResultFragment : Fragment() {
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        binding = DataBindingUtil.inflate(inflater, R.layout.fragment_search_result, container, false)
+        binding =
+            DataBindingUtil.inflate(inflater, R.layout.fragment_search_result, container, false)
         return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         navigator = Navigation.findNavController(view)
-        val adapter = SearchResultAdapter({ openDetail() }) {
-            addWish()
+        val adapter = SearchResultAdapter({ accommodationId ->
+            openDetail(accommodationId)
+        }) { accommodationId ->
+            addWish(accommodationId)
         }
+
         firstPageUpdate()
         binding.iBtnSearchResultSearchCondition.setOnClickListener {
             navigator.navigate(R.id.action_searchResultFragment_to_searchConditionFragment)
         }
-        binding.condtion= viewModel.searchCondition.value
+        binding.condtion = viewModel.searchCondition.value
 
         binding.btnMapView.setOnClickListener {
             navigator.navigate(R.id.action_searchResultFragment_to_mapSearchActivity)
@@ -75,12 +81,17 @@ class SearchResultFragment : Fragment() {
         }
     }
 
-    private fun openDetail() {
+    private fun openDetail(accommodationId: Int) {
+        val condition = viewModel.searchCondition.value
+        val selectedAccommodationDetailBundle = bundleOf("id" to accommodationId, "condition" to condition)
         //navigate to detail
-        navigator.navigate(R.id.action_searchResultFragment_to_accommodationActivity)
+        navigator.navigate(
+            R.id.action_searchResultFragment_to_accommodationActivity,
+            selectedAccommodationDetailBundle
+        )
     }
+}
 
-    private fun addWish() {
-        //To Do: Add Item Wish Page
-    }
+private fun addWish(accommodationId: Int) {
+    //To Do: Add Item Wish Page
 }

--- a/android/app/src/main/res/layout/activity_accommodation_detail.xml
+++ b/android/app/src/main/res/layout/activity_accommodation_detail.xml
@@ -4,9 +4,18 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
+
         <variable
             name="accommodationDetail"
             type="com.example.airbnb.domain.model.AccommodationDetailItem" />
+
+        <variable
+            name="viewPagerCurrentPage"
+            type="int" />
+
+        <variable
+            name="accommodationCondition"
+            type="com.example.airbnb.domain.model.SearchCondition" />
 
     </data>
 
@@ -71,13 +80,14 @@
 
                 <TextView
                     style="@style/Caption.White"
+                    bindViewPagerCurrentPage="@{viewPagerCurrentPage}"
+                    bindViewPagerTap="@{accommodationDetail.accommodationImages}"
                     android:layout_width="72dp"
                     android:layout_height="wrap_content"
                     android:layout_margin="16dp"
                     android:background="@drawable/background_radius_grey"
                     android:gravity="center"
                     android:padding="8dp"
-                    android:text="1/18"
                     app:layout_constraintBottom_toBottomOf="@id/vp_accommodation"
                     app:layout_constraintEnd_toEndOf="parent" />
 
@@ -89,7 +99,7 @@
                     android:layout_marginHorizontal="16dp"
                     android:layout_marginTop="24dp"
                     android:maxLines="2"
-                    android:text="Spacious and Comfortable cozy house #4"
+                    android:text="@{accommodationDetail.name}"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/vp_accommodation" />
@@ -97,11 +107,12 @@
                 <TextView
                     android:id="@+id/tv_accommodation_detail_review"
                     style="@style/Subtitle2.Grey"
+                    bindComments="@{accommodationDetail.commentSize}"
+                    bindRatings="@{accommodationDetail.averageRating}"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="10dp"
                     android:drawablePadding="5dp"
-                    android:text="4.70(후기 127개)"
                     app:drawableStartCompat="@drawable/ic_star"
                     app:layout_constraintStart_toStartOf="@id/tv_accommodation_detail_title"
                     app:layout_constraintTop_toBottomOf="@id/tv_accommodation_detail_title" />
@@ -112,7 +123,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="10dp"
-                    android:text="서초구, 서울, 한국"
+                    android:text="@{accommodationDetail.address}"
                     app:layout_constraintStart_toStartOf="@id/tv_accommodation_detail_review"
                     app:layout_constraintTop_toBottomOf="@id/tv_accommodation_detail_review" />
 
@@ -133,24 +144,26 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="24dp"
-                    android:text="레지던스 전체"
+                    android:text="@{accommodationDetail.accommodationType}"
                     app:layout_constraintStart_toStartOf="@id/view_divider_first"
                     app:layout_constraintTop_toBottomOf="@id/view_divider_first" />
 
                 <TextView
                     android:id="@+id/tv_accommodation_detail_host"
                     style="@style/HeadLine6.Black"
+                    bindHostName="@{accommodationDetail.hostName}"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="4dp"
-                    android:text="호스트 : 히데"
                     app:layout_constraintStart_toStartOf="@id/tv_accommodation_detail_room_type"
                     app:layout_constraintTop_toBottomOf="@id/tv_accommodation_detail_room_type" />
 
                 <ImageView
                     android:id="@+id/iv_accommodation_detail_host"
+                    imageUrl="@{accommodationDetail.hostProfileImage}"
                     android:layout_width="56dp"
                     android:layout_height="56dp"
+                    android:scaleType="centerCrop"
                     app:layout_constraintEnd_toEndOf="@id/view_divider_first"
                     app:layout_constraintTop_toTopOf="@id/tv_accommodation_detail_room_type"
                     tools:srcCompat="@tools:sample/avatars" />
@@ -158,10 +171,13 @@
                 <TextView
                     android:id="@+id/tv_accommodation_detail_room_count"
                     style="@style/Subtitle2.Grey"
+                    bindBathRooms="@{accommodationDetail.bathRooms}"
+                    bindBedRooms="@{accommodationDetail.bedRooms}"
+                    bindBeds="@{accommodationDetail.beds}"
+                    bindMaxPeople="@{accommodationDetail.maxNumberOfPeople}"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="16dp"
-                    android:text="최대인원 3명 - 원룸 - 침대 1개 - 욕실 1개"
                     app:layout_constraintStart_toStartOf="@id/tv_accommodation_detail_host"
                     app:layout_constraintTop_toBottomOf="@id/tv_accommodation_detail_host" />
 
@@ -185,7 +201,7 @@
                     android:layout_marginEnd="16dp"
                     android:ellipsize="end"
                     android:maxLines="3"
-                    android:text="강남역 5번 출구에서 도보로 이동가능합니다. 지하철, 버스 노선이 다양하고 맛집, 마트 등 주변 시설이 풍부합니다. 깨끗하고, 아늑한 히데가 사는 집입니다."
+                    android:text="@{accommodationDetail.description}"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="@id/view_divider_second"
                     app:layout_constraintTop_toBottomOf="@id/view_divider_second" />
@@ -210,6 +226,7 @@
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/cl_accommodation_detail_reservation"
+            isReservationLayout="true"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:background="@color/grey_scale_off_white"
@@ -221,22 +238,23 @@
             <TextView
                 android:id="@+id/tv_accommodation_detail_reservation_day_price"
                 style="@style/Subtitle1.Black"
+                bindOneDayPrice="@{accommodationDetail.oneDayPerPrice}"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="16dp"
                 android:layout_marginTop="16dp"
-                android:text="82,953/박"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
 
             <TextView
                 android:id="@+id/tv_accommodation_detail_reservation_period"
                 style="@style/Subtitle2"
+                bindReservationCheckIn="@{accommodationCondition.checkInDate}"
+                bindReservationCheckOut="@{accommodationCondition.checkOutDate}"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="4dp"
                 android:layout_marginBottom="19dp"
-                android:text="5월 25일 - 5월 28일"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintStart_toStartOf="@id/tv_accommodation_detail_reservation_day_price"
                 app:layout_constraintTop_toBottomOf="@id/tv_accommodation_detail_reservation_day_price" />
@@ -248,7 +266,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginEnd="16dp"
                 android:background="@drawable/btn_radius_black"
-                android:text="예약하기"
+                android:text="@string/accommodation_detail_reservation"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toTopOf="@+id/tv_accommodation_detail_reservation_day_price" />
 
@@ -256,10 +274,10 @@
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/cl_accommodation_detail_input_information"
+            isReservationLayout="false"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:background="@color/grey_scale_off_white"
-            android:visibility="gone"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
@@ -286,7 +304,7 @@
                 android:layout_marginEnd="16dp"
                 android:layout_marginBottom="18dp"
                 android:background="@drawable/btn_radius_black"
-                android:text="예약하기"
+                android:text="@string/accommodation_detail_input_information"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toEndOf="@+id/tv_accommodation_detail_input_information_description"

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -44,4 +44,12 @@
     <string name="reservation_service">서비스</string>
     <string name="reservation_tax">숙박세와 수수료</string>
     <string name="reservation_total">합계</string>
+    <string name="accommodation_detail_host">호스트 : %s</string>
+    <string name="accommodation_detail_view_pager_number">%d/%d</string>
+    <string name="accommodation_detail_rating_comments">%s(후기: %d개)</string>
+    <string name="accommodation_detail_rooms_detail">최대 인원: %d명, 침실 %d개, 침대 %d개, 욕실 %d개</string>
+    <string name="accommodation_detail_one_day_price">₩%s /박</string>
+    <string name="accommodation_detail_reservation">예약하기</string>
+    <string name="accommodation_detail_input_information">정보 입력 하기</string>
+    <string name="accommodation_detail_checkin_checkout">%s - %s</string>
 </resources>


### PR DESCRIPTION
## Issue
- close #96 

## OverView
- 실제 api 적용, dto 변경, 페이징 처리 수정
- 로그인 Oauth Api 일부 구현과 토큰 SharedPreference에 저장 구현
- Api 통신을 통해 받은 숙소 상세 페이지 데이터를 UI에 데이터 바인딩 완료
- 검색 결과에서 숙소를 클릭하면 해당 숙소의 id와 조건값을 상세 페이지 액티비티에 bundle 을 통해 전달
- 전달받은 id와 조건값에 따라 UI에 바인딩 완료
- 체크아웃 날짜가 있으면 예약하기 버튼이, 없으면 정보를 입력할 수 있도록 UI 구현